### PR TITLE
fix: :bug: stop error information from execFile being lost

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,12 +13,7 @@ function ffprobeExecFile (path, args) {
   return new Promise((resolve, reject) => {
     execFile(path, args, (err, stdout, stderr) => {
       if (err) {
-        if (err.code === 'ENOENT') {
           reject(err)
-        } else {
-          const ffprobeErr = new Error(stderr.split('\n').pop())
-          reject(ffprobeErr)
-        }
       } else {
         resolve(JSON.parse(stdout))
       }


### PR DESCRIPTION
## Context

In using this for my own package, one of my users encountered an error which appears to be coming from ffprobe. However the error message coming from ffprobe-client was not helpful.

## Objective

Pass the error object from ffprobe-client directly in all cases, and allow the calling code to deal with parsing the error object.
